### PR TITLE
Query param fetching fix

### DIFF
--- a/src/Http/Service/Factory/RequestFactory.php
+++ b/src/Http/Service/Factory/RequestFactory.php
@@ -71,14 +71,14 @@ class RequestFactory
     {
         $this->requestValidator->assertValidRequest($request);
 
-        $includeString = $request->query->get(GetResourceRequest::INCLUDE_KEY, null);
+        $includeString = $request->query->all()[GetResourceRequest::INCLUDE_KEY] ?? null;
         $include = null;
         if (null !== $includeString) {
             $include = explode(',', $includeString);
         }
 
-        /** @var array<string,string> $fields */
-        $fields = $request->query->get(GetResourceRequest::FIELDS_KEY, null);
+        /** @var null|array<string,string> $fields */
+        $fields = $request->query->all()[GetResourceRequest::FIELDS_KEY] ?? null;
 
         return new GetResourceRequest($id, $include, $fields);
     }
@@ -90,28 +90,26 @@ class RequestFactory
     {
         $this->requestValidator->assertValidRequest($request);
 
-        $sortSet = $request->query->has(GetResourceCollectionRequest::SORT_KEY)
-            ? SortSet::make($request->query->get(GetResourceCollectionRequest::SORT_KEY) ?? '')
-            : null;
+        $sortFromRequest = $request->query->all()[GetResourceCollectionRequest::SORT_KEY] ?? '';
+        $sortSet = (true === \is_string($sortFromRequest) && false === empty($sortFromRequest)) ? SortSet::make($sortFromRequest) : null;
 
         /** @var array<string,int> $paginationFromRequest */
-        $paginationFromRequest = $request->query->get(GetResourceCollectionRequest::PAGINATION_KEY) ?? [];
+        $paginationFromRequest = $request->query->all()[GetResourceCollectionRequest::PAGINATION_KEY] ?? [];
         $pagination = false === empty($paginationFromRequest)
             ? (new PaginationFactory())->fromArray($paginationFromRequest)
             : null;
 
-        /** @var array<string,string> $filterFromRequest */
-        $filterFromRequest = $request->query->get(GetResourceCollectionRequest::FILTER_KEY);
-        $filterSet = $request->query->has(GetResourceCollectionRequest::FILTER_KEY)
-            ? FilterSet::fromArray($filterFromRequest)
+        /** @var null|array<string,string> $filterFromRequest */
+        $filterFromRequest = $request->query->all()[GetResourceCollectionRequest::FILTER_KEY] ?? null;
+        $filterSet = null !== $filterFromRequest ? FilterSet::fromArray($filterFromRequest) : null;
+
+        $includeFromRequest = $request->query->all()[GetResourceCollectionRequest::INCLUDE_KEY] ?? '';
+        $include = (true === \is_string($includeFromRequest) && false === empty($includeFromRequest))
+            ? explode(',', $includeFromRequest)
             : null;
 
-        $include = $request->query->has(GetResourceCollectionRequest::INCLUDE_KEY)
-            ? explode(',', $request->query->get(GetResourceCollectionRequest::INCLUDE_KEY) ?? '')
-            : null;
-
-        /** @var array<int,string> $fields */
-        $fields = $request->query->get(GetResourceCollectionRequest::FIELDS_KEY, null);
+        /** @var null|array<int,string> $fields */
+        $fields = $request->query->all()[GetResourceCollectionRequest::FIELDS_KEY] ?? null;
 
         return new GetResourceCollectionRequest($pagination, $filterSet, $sortSet, $include, $fields);
     }

--- a/tests/Unit/Request/GetResourceCollectionRequestTest.php
+++ b/tests/Unit/Request/GetResourceCollectionRequestTest.php
@@ -41,9 +41,7 @@ final class GetResourceCollectionRequestTest extends TestCase
 
     public function testItWithoutAnyParametersCanBeConstructed(): void
     {
-//        $parameterBagMock = $this->createMock(ParameterBag::class);
-//        $requestMock = $this->createMock(Request::class);
-        $this->parameterBagMock->method('get')->willReturn(null);
+        $this->parameterBagMock->method('all')->willReturn([]);
 
         $getResourceCollectionRequest = $this->requestFactory->getResourceCollectionRequest($this->requestMock);
         static::assertInstanceOf(GetResourceCollectionRequest::class, $getResourceCollectionRequest);
@@ -58,22 +56,15 @@ final class GetResourceCollectionRequestTest extends TestCase
     public function testItWithAllValidParametersCanBeConstructed(): void
     {
         $queryParamsMap = [
-            ['page', null, ['number' => 3, 'size' => 10]],
-            ['filter', null, ['priceMin' => 3, 'priceMax' => 10.5, 'name' => 'John']],
-            ['sort', null, 'name,-price,author.name'],
-            ['include', null, 'category,history,purchases'],
-            ['fields', null, ['author' => 'name,price,rating', 'book' => 'title,publisher']],
+            'page' => ['number' => 3, 'size' => 10],
+            'filter' => ['priceMin' => 3, 'priceMax' => 10.5, 'name' => 'John'],
+            'sort' => 'name,-price,author.name',
+            'include' => 'category,history,purchases',
+            'fields' => ['author' => 'name,price,rating', 'book' => 'title,publisher'],
         ];
 
-        $this->parameterBagMock->method('get')->willReturnMap($queryParamsMap);
+        $this->parameterBagMock->method('all')->willReturn($queryParamsMap);
 
-        $this->parameterBagMock->method('has')->willReturnCallback(static function ($param) use ($queryParamsMap) {
-            $filtered = array_filter($queryParamsMap, static function ($item) use ($param) {
-                return ($item[0] ?? null) === $param;
-            });
-
-            return 1 === \count($filtered);
-        });
         $this->requestMock->query = $this->parameterBagMock;
 
         $getResourceCollectionRequest = $this->requestFactory->getResourceCollectionRequest($this->requestMock);


### PR DESCRIPTION
In version 5 of Symfony usage of get() method on request is deprecated when the array is expected to be return type. In version 6 it will throw an exception. This PR removed usage of get() method on all Symfony request objects.
For more info see: https://symfony.com/doc/current/components/http_foundation.html#accessing-request-data