### PR TITLE
Allow local id in the request

### DIFF
--- a/src/Http/Service/Validation/RequestValidator.php
+++ b/src/Http/Service/Validation/RequestValidator.php
@@ -117,4 +117,11 @@ class RequestValidator implements RequestValidatorInterface
 
         Assertion::same($data['id'], $id, 'Resource with invalid ID given');
     }
+
+    public function assertResourceLidIsValid(array $requestPrimaryData): void
+    {
+        if (true === \array_key_exists('lid', $requestPrimaryData)) {
+            Assertion::string($requestPrimaryData['lid']);
+        }
+    }
 }

--- a/tests/Unit/Http/Service/Factory/RequestFactoryTest.php
+++ b/tests/Unit/Http/Service/Factory/RequestFactoryTest.php
@@ -302,5 +302,24 @@ final class RequestFactoryTest extends TestCase
             '{"data": {"foo": "bar"}}',
             false,
         ];
+
+        yield 'Create request have lid' => [
+            '{"data": {"lid": "123", "foo": "bar"}}',
+            false,
+        ];
+    }
+
+    public function testCreateResourceRequestWillReturnResourceWithLidAsRequestIdentifierGivenRequestHasLidInBody(): void
+    {
+        $lid = '123';
+        $request = $this->createMock(Request::class);
+        $request->expects(static::once())->method('getContent')->willReturn('{"data": {"lid": "123", "foo": "bar"}}');
+        $resource = new Resource($lid, 'type', new AttributeCollection([new Attribute('foo', 'bar')]));
+        $this->resourceEncoderMock
+            ->expects(static::once())
+            ->method('decode')
+            ->willReturn($resource);
+
+        static::assertEquals($lid, $this->requestFactory->createResourceRequest($request)->getResource()->getId());
     }
 }


### PR DESCRIPTION
Updated JSON:API documentation allows local id (lid) to be passed in the request. The lid represents the id on the client side and must not be taken as a new resource id but it can be referenced when bulk creation specification goes live. Check more about lid here https://jsonapi.org/format/#document-resource-object-identification.